### PR TITLE
Improve log messages

### DIFF
--- a/pypmc/__init__.py
+++ b/pypmc/__init__.py
@@ -8,32 +8,6 @@ from ._version import __version__
 # import these submodules by default
 from . import mix_adapt, density, sampler, tools
 
-_log_to_stdout = False
-def log_to_stdout(verbose=False):
-    '''
-    Turn on logging and add a handler which prints to stderr, if not active
-    yet.
-
-    :param verbose:
-
-        Bool; if ``True``, output non-critical status information
-
-    '''
-    global _log_to_stdout
-    import logging
-    import sys
-    logger = logging.getLogger(__name__)
-
-    if verbose:
-        logger.setLevel(logging.INFO)
-    else:
-        logger.setLevel(logging.WARNING)
-
-    if not _log_to_stdout:
-        formatter = logging.Formatter('[%(levelname)s] %(message)s')
-        handler = logging.StreamHandler(sys.stdout)
-        handler.setFormatter(formatter)
-        logger.addHandler(handler)
-        _log_to_stdout = True
-
-log_to_stdout()
+# Log to stdout per default. The log handler can be removed to use pypmc
+# as a library.
+tools.util.log_to_stdout()

--- a/pypmc/__init__.py
+++ b/pypmc/__init__.py
@@ -7,3 +7,33 @@ from ._version import __version__
 
 # import these submodules by default
 from . import mix_adapt, density, sampler, tools
+
+_log_to_stdout = False
+def log_to_stdout(verbose=False):
+    '''
+    Turn on logging and add a handler which prints to stderr, if not active
+    yet.
+
+    :param verbose:
+
+        Bool; if ``True``, output non-critical status information
+
+    '''
+    global _log_to_stdout
+    import logging
+    import sys
+    logger = logging.getLogger(__name__)
+
+    if verbose:
+        logger.setLevel(logging.INFO)
+    else:
+        logger.setLevel(logging.WARNING)
+
+    if not _log_to_stdout:
+        formatter = logging.Formatter('[%(levelname)s] %(message)s')
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        _log_to_stdout = True
+
+log_to_stdout()

--- a/pypmc/mix_adapt/hierarchical.py
+++ b/pypmc/mix_adapt/hierarchical.py
@@ -56,7 +56,7 @@ class Hierarchical(object):
         # the i-th element is :math:`min_j KL(f_i || g_j)`
         self.min_kl = np.zeros(self.nin) + np.inf
 
-    def _cleanup(self, kill, verbose):
+    def _cleanup(self, kill):
         """Look for dead components (weight=0) and remove them
         if enabled by ``kill``.
         Resize storage. Recompute determinant and covariance.
@@ -175,18 +175,18 @@ class Hierarchical(object):
 
              Perform a maximum number of update steps.
 
-        :param verbose:
-
-             Output information on progress of algorithm.
-
         """
+        if verbose:
+            from pypmc.tools.util import depr_warn_verbose
+            depr_warn_verbose(__name__)
+
         old_distance = np.finfo(np.float64).max
         new_distance = np.finfo(np.float64).max
 
         logger.info('Starting hierarchical clustering with %d components.' % len(self.g.components))
         converged = False
         for step in range(1, max_steps + 1):
-            self._cleanup(kill, verbose)
+            self._cleanup(kill)
             self._regroup()
             self._refit()
 
@@ -211,7 +211,7 @@ class Hierarchical(object):
             # save distance for comparison in next step
             old_distance = new_distance
 
-        self._cleanup(kill, verbose)
+        self._cleanup(kill)
         logger.info('%d components remain.' % len(self.g.components))
 
         if converged:

--- a/pypmc/mix_adapt/hierarchical.py
+++ b/pypmc/mix_adapt/hierarchical.py
@@ -5,6 +5,9 @@ import copy
 import numpy as np
 import scipy.linalg as linalg
 
+import logging
+logger = logging.getLogger(__name__)
+
 class Hierarchical(object):
     """Hierarchical clustering as described in [GR04]_.
 
@@ -64,8 +67,8 @@ class Hierarchical(object):
 
             self.nout -= len(removed_indices)
 
-            if verbose and removed_indices:
-                print('Removing %s' % removed_indices)
+            if removed_indices:
+                logger.info('Removing %s' % removed_indices)
 
             for j in removed_indices:
                 self.inv_map.pop(j[0])
@@ -180,8 +183,7 @@ class Hierarchical(object):
         old_distance = np.finfo(np.float64).max
         new_distance = np.finfo(np.float64).max
 
-        if verbose:
-            print('Starting hierarchical clustering with %d components.' % len(self.g.components))
+        logger.info('Starting hierarchical clustering with %d components.' % len(self.g.components))
         converged = False
         for step in range(1, max_steps + 1):
             self._cleanup(kill, verbose)
@@ -191,12 +193,10 @@ class Hierarchical(object):
             new_distance = self._distance()
             assert new_distance >= 0, 'Found non-positive distance %d' % new_distance
 
-            if verbose:
-                print('Distance in step %d: %g' % (step, new_distance))
+            logger.info('Distance in step %d: %g' % (step, new_distance))
             if new_distance == old_distance:
                 converged = True
-                if verbose:
-                    print('Exact minimum found after %d steps' % step)
+                logger.info('Exact minimum found after %d steps' % step)
                 break
 
             rel_change = (old_distance - new_distance) / old_distance
@@ -204,16 +204,15 @@ class Hierarchical(object):
 
             if rel_change < eps and not converged and step > 0:
                 converged = True
-                if verbose and new_distance != old_distance:
-                    print('Close enough to local minimum after %d steps' % step)
+                if new_distance != old_distance:
+                    logger.info('Close enough to local minimum after %d steps' % step)
                 break
 
             # save distance for comparison in next step
             old_distance = new_distance
 
         self._cleanup(kill, verbose)
-        if verbose:
-            print('%d components remain.' % len(self.g.components))
+        logger.info('%d components remain.' % len(self.g.components))
 
         if converged:
             return step

--- a/pypmc/mix_adapt/hierarchical_test.py
+++ b/pypmc/mix_adapt/hierarchical_test.py
@@ -29,7 +29,7 @@ class TestHierarchical(unittest.TestCase):
 
     def test_prune(self):
         h = Hierarchical(self.input_components1, self.initial_guess1)
-        h.run(verbose=True)
+        h.run()
         sol = h.g
 
         # only one component should survive and have weight 1.0
@@ -46,7 +46,7 @@ class TestHierarchical(unittest.TestCase):
 
     def test_cluster(self):
         h = Hierarchical(self.input_components2, self.initial_guess2)
-        h.run(verbose=True)
+        h.run()
         sol = h.g
 
         # both components should survive and have equal weight

--- a/pypmc/mix_adapt/pmc.pyx
+++ b/pypmc/mix_adapt/pmc.pyx
@@ -429,11 +429,11 @@ class PMC(object):
             .. math::
                 \| L_t - L_{t-1} \| < \epsilon_a .
 
-        :param verbose:
-
-            Output status information after each update.
-
         '''
+        if verbose:
+            from pypmc.tools.util import depr_warn_verbose
+            depr_warn_verbose( __name__)
+
         old_K = None
 
         for i in range(1, iterations + 1):

--- a/pypmc/mix_adapt/pmc_test.py
+++ b/pypmc/mix_adapt/pmc_test.py
@@ -390,7 +390,7 @@ class TestGaussianPMCMultipleUpdates(unittest.TestCase):
 
     def test_adaptation(self):
         pmc = PMC(self.samples, self.prop, self.weights, latent=self.latent, rb=False)
-        converged = pmc.run(verbose=True)
+        converged = pmc.run()
         outdensity = pmc.density
 
         self.assertEqual(converged, 2)
@@ -422,7 +422,7 @@ class TestGaussianPMCMultipleUpdates(unittest.TestCase):
         samples, latent = target.propose(10**4, trace=True, shuffle=False)
 
         pmc = PMC(samples, prop, latent=latent, rb=True)
-        pmc.run(verbose=True)
+        pmc.run()
         adapted_prop = pmc.density
 
         adapted_comp_weights = adapted_prop.weights
@@ -467,7 +467,7 @@ class TestGaussianPMCMultipleUpdates(unittest.TestCase):
 
         pmc = PMC(samples, prop, rb=True)
         pmc_prune = 0.5 / len(prop)
-        converge_step = pmc.run(30, verbose=True, prune=pmc_prune)
+        converge_step = pmc.run(30, prune=pmc_prune)
         adapted_prop = pmc.density
 
         adapted_comp_weights = adapted_prop.weights
@@ -520,7 +520,7 @@ class TestStudentTPMCMultipleUpdates(unittest.TestCase):
 
         pmc = PMC(samples, prop, rb=True, mindof=mindof, maxdof=maxdof)
         pmc_prune = 0.5 / len(prop)
-        converge_step = pmc.run(30, verbose=True, prune=pmc_prune)
+        converge_step = pmc.run(30, prune=pmc_prune)
         adapted_prop = pmc.density
 
         adapted_comp_weights = adapted_prop.weights

--- a/pypmc/mix_adapt/variational.pyx
+++ b/pypmc/mix_adapt/variational.pyx
@@ -315,10 +315,11 @@ class GaussianInference(object):
             .. math::
                 \| L_t - L_{t-1} \| < \epsilon_a .
 
-        :param verbose:
-            Output status information after each update.
-
         '''
+        if verbose:
+            from pypmc.tools.util import depr_warn_verbose
+            depr_warn_verbose( __name__)
+
         old_K = None
         for i in range(1, iterations + 1):
             # recompute bound in 1st step or if components were removed

--- a/pypmc/mix_adapt/variational_test.py
+++ b/pypmc/mix_adapt/variational_test.py
@@ -344,7 +344,7 @@ class TestGaussianInference(unittest.TestCase):
         samples = sam.samples[:]
 
         clust = GaussianInference(samples, 2, weights=weights, m=np.vstack((prop_mean1,prop_mean2)))
-        converged = clust.run(verbose=True)
+        converged = clust.run()
         self.assertTrue(converged)
 
         resulting_mixture = clust.make_mixture()
@@ -418,7 +418,7 @@ class TestGaussianInference(unittest.TestCase):
         # to result in same numbers, except it works also when
         # components were reduced => nsteps2 + 1
         eps = 1e-15
-        nsteps2 = infer2.run(20, verbose=True)
+        nsteps2 = infer2.run(20)
         self.assertEqual(nsteps2 + 1, nsteps)
 
         result2 = infer2.make_mixture()
@@ -493,7 +493,7 @@ class TestVBMerge(unittest.TestCase):
 
     def test_1d(self):
         vb = VBMerge(self.input_mix, N=self.N, initial_guess=self.initial_guess)
-        vb.run(verbose=True)
+        vb.run()
         mix = vb.make_mixture()
         self.assertEqual(len(mix), 1)
         # means agree as m0 = 0 but correction from beta0
@@ -609,7 +609,7 @@ class TestVBMerge(unittest.TestCase):
         # restart, should converge immediately
         pripos = vb.prior_posterior()
         vb2 = VBMerge(input_mix, vb.N, **pripos)
-        nsteps = vb2.run(verbose=True)
+        nsteps = vb2.run()
         self.assertEqual(nsteps, 1)
         self.assertEqual(vb2.likelihood_bound(), vb.likelihood_bound())
 
@@ -699,7 +699,7 @@ class TestVBMerge(unittest.TestCase):
         # converge exactly in two steps
         # prune out one component after first update
         # then get same bound twice
-        self.assertEqual(vb.run(verbose=True), 2)
+        self.assertEqual(vb.run(), 2)
         self.assertEqual(vb.K, 1)
         res = vb.make_mixture()
         np.testing.assert_allclose(res.components[0].mu   , target_mean,  rtol=1e-3)

--- a/pypmc/sampler/markov_chain.py
+++ b/pypmc/sampler/markov_chain.py
@@ -6,6 +6,9 @@ from ..tools import History as _History
 from ..tools.indicator import merge_function_with_indicator as _indmerge
 from ..tools._doc import _inherit_docstring
 
+import logging
+logger = logging.getLogger(__name__)
+
 class MarkovChain(object):
     r"""A Markov chain to generate samples from the target density.
 
@@ -375,15 +378,15 @@ class AdaptiveMarkovChain(MarkovChain):
         try:
             self.proposal.update(scaled_sigma)
         except _np.linalg.LinAlgError:
-            print("WARNING: Markov chain self adaptation failed; trying diagonalization ... ", end='')
+            logger.warning("Markov chain self adaptation failed; trying diagonalization")
             # try to insert offdiagonal elements only
             diagonal_matrix = _np.zeros_like(scaled_sigma)
             _np.fill_diagonal(diagonal_matrix, _np.diag(scaled_sigma))
             try:
                 self.proposal.update(diagonal_matrix)
-                print('success')
+                logger.warning('Diagonalization succeeded')
             except _np.linalg.LinAlgError:
-                print('fail')
+                logger.warning('Diagonalization failed')
                 # just scale the old covariance matrix if everything else fails
                 self.proposal.update(self.proposal.sigma / self.covar_scale_multiplier)
 

--- a/pypmc/tools/__init__.py
+++ b/pypmc/tools/__init__.py
@@ -5,4 +5,4 @@
 from ._history import History
 from ._partition import partition, patch_data
 from ._plot import plot_mixture, plot_responsibility
-from . import indicator, convergence
+from . import indicator, convergence, util

--- a/pypmc/tools/_partition.py
+++ b/pypmc/tools/_partition.py
@@ -48,11 +48,11 @@ def patch_data(data, L=100, try_diag=True, verbose=False):
         that fails as well, the patch is skipped.
         If ``False`` the patch is skipped directly.
 
-    :param verbose:
-
-        Bool; If ``True`` print all status information.
-
     '''
+    if verbose:
+        from pypmc.tools.util import depr_warn_verbose
+        depr_warn_verbose(__name__)
+
     # patch data into length L patches
     patches = _np.array([data[patch_start:patch_start + L] for patch_start in range(0, len(data), L)])
 

--- a/pypmc/tools/_partition.py
+++ b/pypmc/tools/_partition.py
@@ -6,6 +6,9 @@ import numpy as _np
 from ..density.gauss import Gauss
 from ..density.mixture import MixtureDensity
 
+import logging
+logger = logging.getLogger(__name__)
+
 def partition(N, k):
     '''Distribute ``N`` into ``k`` parts such that each part
     takes the value ``N//k`` or ``N//k + 1`` where ``//`` denotes integer
@@ -65,25 +68,22 @@ def patch_data(data, L=100, try_diag=True, verbose=False):
             this_comp = Gauss(mean, cov)
             components.append(this_comp)
         except _np.linalg.LinAlgError as error1:
-            if verbose:
-                print("Could not form Gauss from patch %i. Reason: %s" % (i, repr(error1)))
+            logger.info("Could not form Gauss from patch %i. Reason: %s" % (i, repr(error1)))
             if try_diag:
                 cov = _np.diag(_np.diag(cov))
                 try:
                     this_comp = Gauss(mean, cov)
                     components.append(this_comp)
-                    if verbose:
-                        print('Diagonal covariance attempt succeeded.')
+                    logger.info('Diagonal covariance attempt succeeded.')
                 except _np.linalg.LinAlgError as error2:
                     skipped.append(i)
-                    if verbose:
-                        print("Diagonal covariance attempt failed. Reason: %s" % repr(error2))
+                    logger.info("Diagonal covariance attempt failed. Reason: %s" % repr(error2))
             else: # if not try_diag
                 skipped.append(i)
 
     # print skipped components if any
     if skipped:
-        print("WARNING: Could not form Gaussians from: %s" % skipped)
+        logger.warning("Could not form Gaussians from: %s" % skipped)
 
     # create and return mixture
     return MixtureDensity(components)

--- a/pypmc/tools/util.py
+++ b/pypmc/tools/util.py
@@ -1,0 +1,38 @@
+import logging
+
+_log_to_stdout = False
+def log_to_stdout(verbose=False):
+    '''
+    Turn on logging and add a handler which prints to stderr, if not active
+    yet.
+
+    :param verbose:
+
+        Bool; if ``True``, output non-critical status information
+
+    '''
+    global _log_to_stdout
+    import logging
+    import sys
+    logger = logging.getLogger(__name__)
+
+    if verbose:
+        logger.setLevel(logging.INFO)
+    else:
+        logger.setLevel(logging.WARNING)
+
+    if not _log_to_stdout:
+        formatter = logging.Formatter('[%(levelname)s] %(message)s')
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        _log_to_stdout = True
+
+def depr_warn_verbose(logger_name):
+    logger = logging.getLogger(logger_name)
+    logger.warn(
+            f"The optional argument 'verbose' is deprecated and "
+            f"will be removed in the future. Instead, use the log "
+            f"level of logging.getLogger({logger_name}) or a parent."
+            )
+


### PR DESCRIPTION
This pull request changes the way printing status messages is handled.

 1. All `print` functionality is replaced by the `logging` standard library.
 Messages that were wrapped with `if(verbose)` are logged as information, or as warnings otherwise.
 2. The new function `util.log_to_stdout` sets up a basic logging handler for easy standalone usage of pypmc.
 This function is called in `__init__.py` as a drop-in replacement of the current behaviour.
 
#### Comments
 - Every submodule uses its own logger such that the level of granularity is still high.
   E.g. to only log warnings and errors from PMC, use `logging.getLogger('pypmc.mix_adapt.pmc').setLevel(logging.WARNING)`.
 - Note that the default behaviour of `logging` when no log handler is specified, is to print warnings and errors to stderr.
 - Importing pypmc is setting up a log handler (to stdout), which must be removed explicity to use the module as a library.

#### WIP
- [x] Adding the default StreamHandler creates uncaptured output in the nosetests, as warnings log to stderr. To comply with the previous code, we specify to log only to stdout.
- [x] Emit deprecation notice for optional `verbose` argument instead of removing the option (breaking change).
- [ ] Document logging behaviour and how to use pypmc as a library.
  The [wiki page](https://github.com/pypmc/pypmc/wiki/developer-overview) is a good place to document logging after the proposed changes are approved.

Solves #95