### PR TITLE
[ci] add biweekly scheduled builds to detect breakage

### DIFF
--- a/.github/workflows/manylinx-build+check+deploy.yaml
+++ b/.github/workflows/manylinx-build+check+deploy.yaml
@@ -3,6 +3,8 @@ on:
         branches: [ master, testing ]
 
     pull_request:
+    schedule:
+      - cron: '2 8 3,18 * *'
 
 name: Build/Check/Deploy to PyPI
 


### PR DESCRIPTION
This runs regularly (every 14 days) to detect when something breaks.

see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule

and https://crontab.guru/#2_8_3,18_*_*