### PR TITLE
allow numpy 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel", 'cython>=0.21', 'numpy>=1.6, <2.0']
+requires = ["setuptools>=40.8.0", "wheel", 'cython>=0.21', 'numpy>=2.0']
 build-backend = "setuptools.build_meta:__legacy__"

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ def setup_package():
         description='A toolkit for adaptive importance sampling featuring implementations of variational Bayes, population Monte Carlo, and Markov chains.',
         long_description=long_description,
         license='GPLv2',
-        install_requires=['numpy>=1.6, <2.0', 'scipy'],
+        install_requires=['numpy>=1.6', 'scipy'],
         extras_require={'testing': ['nose'], 'plotting': ['matplotlib'], 'parallelization': ['mpi4py']},
         classifiers=['Development Status :: 5 - Production/Stable',
                      'Intended Audience :: Developers',


### PR DESCRIPTION
It would be nice if this package could be installed with more recent versions of numpy. This makes the minimal changes to setup.py and pyproject to attempt this.

No fixes are yet in place in the library itself though if there are failures. 