### PR TITLE
Switch to using v4 of the artifact actions

### DIFF
--- a/.github/workflows/build+check+deploy.yaml
+++ b/.github/workflows/build+check+deploy.yaml
@@ -52,8 +52,10 @@ jobs:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_TEST_COMMAND: python3 -m unittest discover -s {package} pypmc -p *_test.py
 
-      - uses: actions/upload-artifact@v3
+      - name: Upload wheels as artifacts
+        uses: actions/upload-artifact@v4
         with:
+          name: wheel-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.version }}
           path: ./wheelhouse/*.whl
 
   upload_pypi:
@@ -61,9 +63,10 @@ jobs:
     if: ${{ github.event_name == 'release' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          pattern: wheel-*
+          merge-multiple: true
           path: dist
 
       - uses: pypa/gh-action-pypi-publish@v1.4.2


### PR DESCRIPTION
This is meant to replace PR #106, which introduces a subtle bug when using the v4 artifact actions without merging multiple packages.