### PR TITLE
Build against numpy 2.0

### DIFF
--- a/.github/workflows/build+check+deploy.yaml
+++ b/.github/workflows/build+check+deploy.yaml
@@ -19,19 +19,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - { version: cp38,  arch: x86_64,  os: ubuntu-20.04 }
           - { version: cp39,  arch: x86_64,  os: ubuntu-20.04 }
           - { version: cp310, arch: x86_64,  os: ubuntu-20.04 }
           - { version: cp311, arch: x86_64,  os: ubuntu-20.04 }
-          - { version: cp38,  arch: aarch64, os: ubuntu-20.04 }
           - { version: cp39,  arch: aarch64, os: ubuntu-20.04 }
           - { version: cp310, arch: aarch64, os: ubuntu-20.04 }
           - { version: cp311, arch: aarch64, os: ubuntu-20.04 }
-          - { version: cp38,  arch: x86_64,  os: macOS-latest }
           - { version: cp39,  arch: x86_64,  os: macOS-latest }
           - { version: cp310, arch: x86_64,  os: macOS-latest }
           - { version: cp311, arch: x86_64,  os: macOS-latest }
-          - { version: cp38,  arch: arm64,   os: macOS-latest }
           - { version: cp39,  arch: arm64,   os: macOS-latest }
           - { version: cp310, arch: arm64,   os: macOS-latest }
           - { version: cp311, arch: arm64,   os: macOS-latest }

--- a/.github/workflows/build+check+deploy.yaml
+++ b/.github/workflows/build+check+deploy.yaml
@@ -22,15 +22,19 @@ jobs:
           - { version: cp39,  arch: x86_64,  os: ubuntu-20.04 }
           - { version: cp310, arch: x86_64,  os: ubuntu-20.04 }
           - { version: cp311, arch: x86_64,  os: ubuntu-20.04 }
+          - { version: cp312, arch: x86_64,  os: ubuntu-20.04 }
           - { version: cp39,  arch: aarch64, os: ubuntu-20.04 }
           - { version: cp310, arch: aarch64, os: ubuntu-20.04 }
           - { version: cp311, arch: aarch64, os: ubuntu-20.04 }
+          - { version: cp312, arch: aarch64, os: ubuntu-20.04 }
           - { version: cp39,  arch: x86_64,  os: macOS-latest }
           - { version: cp310, arch: x86_64,  os: macOS-latest }
           - { version: cp311, arch: x86_64,  os: macOS-latest }
+          - { version: cp312, arch: x86_64,  os: macOS-latest }
           - { version: cp39,  arch: arm64,   os: macOS-latest }
           - { version: cp310, arch: arm64,   os: macOS-latest }
           - { version: cp311, arch: arm64,   os: macOS-latest }
+          - { version: cp312, arch: arm64,   os: macOS-latest }
     name: Build wheels on ${{ matrix.os }}/${{ matrix.arch }} for ${{ matrix.version }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/pypmc/density/gauss_test.py
+++ b/pypmc/density/gauss_test.py
@@ -140,7 +140,7 @@ class TestGauss(unittest.TestCase):
     def test_dim_mismatch(self):
         mu    = np.ones(2)
         sigma = np.eye (3)
-        self.assertRaisesRegexp(AssertionError, 'Dimensions of mean \(2\) and covariance matrix \(3\) do not match!', Gauss, mu, sigma)
+        self.assertRaisesRegex(AssertionError, 'Dimensions of mean \(2\) and covariance matrix \(3\) do not match!', Gauss, mu, sigma)
 
     def test_evaluate(self):
         self.assertAlmostEqual(self.comp.evaluate(self.point), self.target)

--- a/pypmc/density/mixture_test.py
+++ b/pypmc/density/mixture_test.py
@@ -114,16 +114,16 @@ class TestMixtureDensity(unittest.TestCase):
         components           = [0]
 
         self.mix.multi_evaluate(samples, individual=individual_ok) # should be ok
-        self.assertRaisesRegexp(AssertionError, 'x.*wrong dim.*',
-                                self.mix.multi_evaluate, samples_wrong_dim, individual=individual_ok)
-        self.assertRaisesRegexp(AssertionError, 'individual.*must.*shape',
-                                self.mix.multi_evaluate, samples, individual=individual_too_short)
-        self.assertRaisesRegexp(AssertionError, 'individual.*must.*shape',
-                                self.mix.multi_evaluate, samples, individual=individual_wrong_K)
-        self.assertRaisesRegexp(AssertionError, 'components.*not None.*out.*must be None',
-                                self.mix.multi_evaluate, samples, out_ok, components=components)
-        self.assertRaisesRegexp(AssertionError, 'out.*must.*len.*3',
-                                self.mix.multi_evaluate, samples, out_too_long)
+        self.assertRaisesRegex(AssertionError, 'x.*wrong dim.*',
+                               self.mix.multi_evaluate, samples_wrong_dim, individual=individual_ok)
+        self.assertRaisesRegex(AssertionError, 'individual.*must.*shape',
+                               self.mix.multi_evaluate, samples, individual=individual_too_short)
+        self.assertRaisesRegex(AssertionError, 'individual.*must.*shape',
+                               self.mix.multi_evaluate, samples, individual=individual_wrong_K)
+        self.assertRaisesRegex(AssertionError, 'components.*not None.*out.*must be None',
+                               self.mix.multi_evaluate, samples, out_ok, components=components)
+        self.assertRaisesRegex(AssertionError, 'out.*must.*len.*3',
+                               self.mix.multi_evaluate, samples, out_too_long)
 
     def test_propose(self):
         np.random.seed(rng_seed)
@@ -169,7 +169,7 @@ class TestMixtureDensity(unittest.TestCase):
 
     def test_no_segfault(self):
         # passing an empty list as ``components`` used to cause segfault
-        self.assertRaisesRegexp(AssertionError, ".*at least.*['one''1'].*component", MixtureDensity, [])
+        self.assertRaisesRegex(AssertionError, ".*at least.*['one''1'].*component", MixtureDensity, [])
 
 means = np.array([[ 1.0,  5.4, -3.1],
                   [-3.8,  2.5,  0.4],
@@ -200,10 +200,10 @@ normalized_weights = weights/weights.sum()
 
 class TestCreateGaussian(unittest.TestCase):
     def test_invalid_input(self):
-        self.assertRaisesRegexp(AssertionError, 'Number of means.*?not match.*?number of cov',
-                                create_gaussian_mixture, means    , covs[:2]   )
-        self.assertRaisesRegexp(AssertionError, 'Number of means.*?not match.*?number of cov',
-                                create_gaussian_mixture, means[:2], covs       )
+        self.assertRaisesRegex(AssertionError, 'Number of means.*?not match.*?number of cov',
+                               create_gaussian_mixture, means    , covs[:2]   )
+        self.assertRaisesRegex(AssertionError, 'Number of means.*?not match.*?number of cov',
+                               create_gaussian_mixture, means[:2], covs       )
 
     def test_create_no_weights(self):
         mix = create_gaussian_mixture(means, covs)
@@ -241,12 +241,12 @@ class TestRecoverGaussian(unittest.TestCase):
 
 class TestCreateStudentT(unittest.TestCase):
     def test_invalid_input(self):
-        self.assertRaisesRegexp(AssertionError, 'Number of.*?means.*?covs.*?dofs.*?not match.',
-                                create_t_mixture, means    , covs[:2], dofs       )
-        self.assertRaisesRegexp(AssertionError, 'Number of.*?means.*?covs.*?dofs.*?not match.',
-                                create_t_mixture, means[:2], covs    , dofs       )
-        self.assertRaisesRegexp(AssertionError, 'Number of.*?means.*?covs.*?dofs.*?not match.',
-                                create_t_mixture, means[:2], covs    , dofs[:2]   )
+        self.assertRaisesRegex(AssertionError, 'Number of.*?means.*?covs.*?dofs.*?not match.',
+                               create_t_mixture, means    , covs[:2], dofs       )
+        self.assertRaisesRegex(AssertionError, 'Number of.*?means.*?covs.*?dofs.*?not match.',
+                               create_t_mixture, means[:2], covs    , dofs       )
+        self.assertRaisesRegex(AssertionError, 'Number of.*?means.*?covs.*?dofs.*?not match.',
+                               create_t_mixture, means[:2], covs    , dofs[:2]   )
 
     def test_create_no_weights(self):
         mix = create_t_mixture(means, covs, dofs)

--- a/pypmc/density/student_t_test.py
+++ b/pypmc/density/student_t_test.py
@@ -50,8 +50,8 @@ class TestLocalStudentT(unittest.TestCase):
 
     def test_bad_dof(self):
         expected_error_msg = ".*dof.*must.*((larger)|(greater)).*(0|(zero))"
-        self.assertRaisesRegexp(AssertionError, expected_error_msg, LocalStudentT, offdiag_sigma,  0.0)
-        self.assertRaisesRegexp(AssertionError, expected_error_msg, LocalStudentT, offdiag_sigma, -1.1)
+        self.assertRaisesRegex(AssertionError, expected_error_msg, LocalStudentT, offdiag_sigma,  0.0)
+        self.assertRaisesRegex(AssertionError, expected_error_msg, LocalStudentT, offdiag_sigma, -1.1)
 
     def test_badCovarianceInput(self):
         self.assertRaises(np.linalg.LinAlgError, lambda: LocalStudentT(singular_sigma, 10) )
@@ -207,7 +207,7 @@ class TestStudentT(unittest.TestCase):
         mu    = np.ones(2)
         sigma = np.eye (3)
         dof   = 4.
-        self.assertRaisesRegexp(AssertionError,
+        self.assertRaisesRegex(AssertionError,
                 'Dimensions of mean \(2\) and covariance matrix \(3\) do not match!',
                 StudentT, mu, sigma, dof)
 

--- a/pypmc/mix_adapt/pmc_test.py
+++ b/pypmc/mix_adapt/pmc_test.py
@@ -57,14 +57,14 @@ class TestGaussianPMCNoOverlap(unittest.TestCase):
                         [-10.4898097 ,   7.48668861,  -2.41443733]])
 
     def test_invalid_usage(self):
-        self.assertRaisesRegexp(ValueError, r'["\'` ]*rb["\'` ]*must.*["\' `]*True["\'` ]* if["\'` ]*latent["\'` ]*.*not',
-                                gaussian_pmc, self.samples, self.prop, self.weights, rb=False)
-        self.assertRaisesRegexp(ValueError, r'["\'` ]*mincount["\'` ]*must.*["\' `]*[0(zero)]["\'` ]* if["\'` ]*latent["\'` ]*.*not',
-                                gaussian_pmc, self.samples, self.prop, self.weights, mincount=10)
-        self.assertRaisesRegexp(ValueError, r'(["\'` ]*mincount["\'` ]*must.*["\' `]*[0(zero)]["\'` ]* if["\'` ]*latent["\'` ]*.*not)' + \
-                                            r'|' + \
-                                            r'(["\'` ]*rb["\'` ]*must.*["\' `]*True["\'` ]* if["\'` ]*latent["\'` ]*.*not)',
-                                gaussian_pmc, self.samples, self.prop, self.weights, mincount=10, rb=False)
+        self.assertRaisesRegex(ValueError, r'["\'` ]*rb["\'` ]*must.*["\' `]*True["\'` ]* if["\'` ]*latent["\'` ]*.*not',
+                               gaussian_pmc, self.samples, self.prop, self.weights, rb=False)
+        self.assertRaisesRegex(ValueError, r'["\'` ]*mincount["\'` ]*must.*["\' `]*[0(zero)]["\'` ]* if["\'` ]*latent["\'` ]*.*not',
+                               gaussian_pmc, self.samples, self.prop, self.weights, mincount=10)
+        self.assertRaisesRegex(ValueError, r'(["\'` ]*mincount["\'` ]*must.*["\' `]*[0(zero)]["\'` ]* if["\'` ]*latent["\'` ]*.*not)' + \
+                                           r'|' + \
+                                           r'(["\'` ]*rb["\'` ]*must.*["\' `]*True["\'` ]* if["\'` ]*latent["\'` ]*.*not)',
+                               gaussian_pmc, self.samples, self.prop, self.weights, mincount=10, rb=False)
 
     def test_mincount_and_copy(self):
         self.prop_weights = self.prop.weights.copy()
@@ -373,19 +373,19 @@ class TestGaussianPMCMultipleUpdates(unittest.TestCase):
         np.random.mtrand.seed(345985345634 % 4294967296)
 
     def test_invalid_usage(self):
-        self.assertRaisesRegexp(ValueError, r'["\'` ]*rb["\'` ]*must.*["\' `]*True["\'` ]* if["\'` ]*latent["\'` ]*.*not',
-                                PMC, self.samples, self.prop, self.weights, rb=False)
-        self.assertRaisesRegexp(ValueError, r'["\'` ]*mincount["\'` ]*must.*["\' `]*[0(zero)]["\'` ]* if["\'` ]*latent["\'` ]*.*not',
-                                PMC, self.samples, self.prop, self.weights, mincount=10)
-        self.assertRaisesRegexp(ValueError, r'(["\'` ]*mincount["\'` ]*must.*["\' `]*[0(zero)]["\'` ]* if["\'` ]*latent["\'` ]*.*not)' + \
-                                            r'|' + \
-                                            r'(["\'` ]*rb["\'` ]*must.*["\' `]*True["\'` ]* if["\'` ]*latent["\'` ]*.*not)',
-                                PMC, self.samples, self.prop, self.weights, mincount=10, rb=False)
+        self.assertRaisesRegex(ValueError, r'["\'` ]*rb["\'` ]*must.*["\' `]*True["\'` ]* if["\'` ]*latent["\'` ]*.*not',
+                               PMC, self.samples, self.prop, self.weights, rb=False)
+        self.assertRaisesRegex(ValueError, r'["\'` ]*mincount["\'` ]*must.*["\' `]*[0(zero)]["\'` ]* if["\'` ]*latent["\'` ]*.*not',
+                               PMC, self.samples, self.prop, self.weights, mincount=10)
+        self.assertRaisesRegex(ValueError, r'(["\'` ]*mincount["\'` ]*must.*["\' `]*[0(zero)]["\'` ]* if["\'` ]*latent["\'` ]*.*not)' + \
+                                           r'|' + \
+                                           r'(["\'` ]*rb["\'` ]*must.*["\' `]*True["\'` ]* if["\'` ]*latent["\'` ]*.*not)',
+                               PMC, self.samples, self.prop, self.weights, mincount=10, rb=False)
 
         invalid_density = None
 
-        self.assertRaisesRegexp(TypeError, r'.*density.*must be.*MixtureDensity',
-                                PMC, self.samples, invalid_density, self.weights)
+        self.assertRaisesRegex(TypeError, r'.*density.*must be.*MixtureDensity',
+                               PMC, self.samples, invalid_density, self.weights)
 
     def test_adaptation(self):
         pmc = PMC(self.samples, self.prop, self.weights, latent=self.latent, rb=False)

--- a/pypmc/mix_adapt/r_value_test.py
+++ b/pypmc/mix_adapt/r_value_test.py
@@ -159,14 +159,14 @@ class TestRGroup(unittest.TestCase):
         # ``covs`` must be 2d
         two_covariances_wrong_shape = np.array(  [1., 2.]  )
 
-        self.assertRaisesRegexp(AssertionError, '.*means.*not match.*variances',
-                                r_group, two_means, three_variances, 10)
-        self.assertRaisesRegexp(AssertionError, '.*means.*must.*[Mm]atrix',
-                                r_group, three_means_wrong_shape, three_variances, 10)
-        self.assertRaisesRegexp(AssertionError, '.*variances.*must.*2[\ -]?[Dd]im',
-                                r_group, two_means, two_covariances_wrong_shape, 10)
-        self.assertRaisesRegexp(AssertionError, 'Dimensionality.*means.*variances.*not match',
-                                r_group, two_means, two_vars_wrong_dimension, 10)
+        self.assertRaisesRegex(AssertionError, '.*means.*not match.*variances',
+                               r_group, two_means, three_variances, 10)
+        self.assertRaisesRegex(AssertionError, '.*means.*must.*[Mm]atrix',
+                               r_group, three_means_wrong_shape, three_variances, 10)
+        self.assertRaisesRegex(AssertionError, '.*variances.*must.*2[\ -]?[Dd]im',
+                               r_group, two_means, two_covariances_wrong_shape, 10)
+        self.assertRaisesRegex(AssertionError, 'Dimensionality.*means.*variances.*not match',
+                               r_group, two_means, two_vars_wrong_dimension, 10)
 
 # making mixtures out of data:
 
@@ -285,13 +285,13 @@ class TestMakeRPatches(unittest.TestCase):
 
             # invalid argument
             kwargs['indices'] = []
-            self.assertRaisesRegexp(AssertionError, 'Invalid.*indices',
-                                    _make_r_patches, index_data, **kwargs)
+            self.assertRaisesRegex(AssertionError, 'Invalid.*indices',
+                                   _make_r_patches, index_data, **kwargs)
 
 class TestMakeRGaussmix(unittest.TestCase):
     def test_error_messages(self):
-        self.assertRaisesRegexp(AssertionError, 'Every chain.*same.*number.*points',
-                                make_r_gaussmix, wrong_data)
+        self.assertRaisesRegex(AssertionError, 'Every chain.*same.*number.*points',
+                               make_r_gaussmix, wrong_data)
 
     def test_make_r_gaussmix(self):
         inferred_mixture = make_r_gaussmix(data, K_g=2, critical_r=critical_r)
@@ -306,12 +306,12 @@ class TestMakeRTmix(unittest.TestCase):
     invalid_dof = 1. # for finite covariance: dof > 2
 
     def test_error_messages(self):
-        self.assertRaisesRegexp(AssertionError, 'Every chain.*same.*number.*points',
-                                make_r_tmix, wrong_data)
-        self.assertRaisesRegexp(AssertionError, 'dof.*(greater|larger).*?2',
-                                make_r_tmix, data, dof=self.invalid_dof)
-        self.assertRaisesRegexp(AssertionError, 'dof.*(greater|larger).*?2',
-                                make_r_tmix, data, dof=2)
+        self.assertRaisesRegex(AssertionError, 'Every chain.*same.*number.*points',
+                               make_r_tmix, wrong_data)
+        self.assertRaisesRegex(AssertionError, 'dof.*(greater|larger).*?2',
+                               make_r_tmix, data, dof=self.invalid_dof)
+        self.assertRaisesRegex(AssertionError, 'dof.*(greater|larger).*?2',
+                               make_r_tmix, data, dof=2)
 
     def test_make_r_tmix(self):
         target_dofs = np.array([self.valid_dof] * 4)

--- a/pypmc/mix_adapt/variational_test.py
+++ b/pypmc/mix_adapt/variational_test.py
@@ -80,19 +80,19 @@ class TestGaussianInference(unittest.TestCase):
         # alpha, m and W should be valid
         GaussianInference(data, components=2, alpha=alpha, m=m, W=W)
 
-        self.assertRaisesRegexp(ValueError, 'either.*components.*or.*initial_guess',
-                                GaussianInference, data)
+        self.assertRaisesRegex(ValueError, 'either.*components.*or.*initial_guess',
+                               GaussianInference, data)
 
         # should not be able to pass both initial_guess and something out of [alpha, beta, nu, m, W]
-        self.assertRaisesRegexp(ValueError, 'EITHER.*W.*OR.*initial_guess',
+        self.assertRaisesRegex(ValueError, 'EITHER.*W.*OR.*initial_guess',
                                GaussianInference, data, initial_guess=target_mix, W=W)
-        self.assertRaisesRegexp(ValueError, 'EITHER.*m.*OR.*initial_guess',
+        self.assertRaisesRegex(ValueError, 'EITHER.*m.*OR.*initial_guess',
                                GaussianInference, data, initial_guess=target_mix, m=m)
-        self.assertRaisesRegexp(ValueError, 'EITHER.*alpha.*OR.*initial_guess',
+        self.assertRaisesRegex(ValueError, 'EITHER.*alpha.*OR.*initial_guess',
                                GaussianInference, data, initial_guess=target_mix, alpha=alpha)
-        self.assertRaisesRegexp(ValueError, 'EITHER.*beta.*OR.*initial_guess',
+        self.assertRaisesRegex(ValueError, 'EITHER.*beta.*OR.*initial_guess',
                                GaussianInference, data, initial_guess=target_mix, beta=beta)
-        self.assertRaisesRegexp(ValueError, 'EITHER.*nu.*OR.*initial_guess',
+        self.assertRaisesRegex(ValueError, 'EITHER.*nu.*OR.*initial_guess',
                                GaussianInference, data, initial_guess=target_mix, nu=nu)
 
 
@@ -132,15 +132,15 @@ class TestGaussianInference(unittest.TestCase):
         np.testing.assert_almost_equal(re_component_weights, normalized_weights                  )
 
         # test default
-        self.assertRaisesRegexp(ValueError, 'Specify ``m``',
-                                GaussianInference, data, len(data) + 10)
+        self.assertRaisesRegex(ValueError, 'Specify ``m``',
+                               GaussianInference, data, len(data) + 10)
         # specify some m with too many components
         GaussianInference(data, len(data) + 10, m=np.zeros((len(data) + 10, 2)))
         GaussianInference(data, K)
 
         # test 'first'
-        self.assertRaisesRegexp(ValueError, 'either.*components.*or.*initial_guess',
-                                GaussianInference, data, initial_guess='first')
+        self.assertRaisesRegex(ValueError, 'either.*components.*or.*initial_guess',
+                               GaussianInference, data, initial_guess='first')
         vb = GaussianInference(data, K, initial_guess='first', alpha0=alpha0, beta0=beta0, nu0=nu0)
         np.testing.assert_equal(vb.m, data[0:K])
 
@@ -470,14 +470,14 @@ class TestVBMerge(unittest.TestCase):
         means, _, _ = recover_gaussian_mixture(self.input_mix)
 
         # test default
-        self.assertRaisesRegexp(ValueError, 'Specify ``m``',
-                                VBMerge, self.input_mix, self.N, 32)
+        self.assertRaisesRegex(ValueError, 'Specify ``m``',
+                               VBMerge, self.input_mix, self.N, 32)
         # specify some m with too many components
         VBMerge(self.input_mix, self.N, 32, m=np.zeros((32, 1)))
         VBMerge(self.input_mix, self.N, K)
         # test 'first'
-        self.assertRaisesRegexp(ValueError, 'either.*components.*or.*initial_guess',
-                                VBMerge, self.input_mix, self.N, initial_guess='first')
+        self.assertRaisesRegex(ValueError, 'either.*components.*or.*initial_guess',
+                               VBMerge, self.input_mix, self.N, initial_guess='first')
 
 
         vb = VBMerge(self.input_mix, self.N, K, initial_guess='first')

--- a/pypmc/sampler/importance_sampling_test.py
+++ b/pypmc/sampler/importance_sampling_test.py
@@ -184,13 +184,13 @@ class TestCalculateExpextaction(unittest.TestCase):
     def test_error_messages(self):
         too_many_weights = [1.,2.,3.,4.]
 
-        with self.assertRaisesRegexp(AssertionError, ".*number of samples.*must.*equal.*number of weights"):
+        with self.assertRaisesRegex(AssertionError, ".*number of samples.*must.*equal.*number of weights"):
             calculate_expectation(self.samples, too_many_weights, lambda x: x)
 
-        with self.assertRaisesRegexp(AssertionError, ".*number of samples.*must.*equal.*number of weights"):
+        with self.assertRaisesRegex(AssertionError, ".*number of samples.*must.*equal.*number of weights"):
             calculate_mean(self.samples, too_many_weights)
 
-        with self.assertRaisesRegexp(AssertionError, ".*number of samples.*must.*equal.*number of weights"):
+        with self.assertRaisesRegex(AssertionError, ".*number of samples.*must.*equal.*number of weights"):
             calculate_covariance(self.samples, too_many_weights)
 
     def test_calculate(self):
@@ -391,21 +391,21 @@ class TestCombineWeights(unittest.TestCase):
                         [weighted_samples_1[:,0],  weighted_samples_2[:,0]],
                         [perfect_prop, perfect_prop])
 
-        with self.assertRaisesRegexp(AssertionError, 'Got 2 importance-sampling runs but 1 proposal densities'):
+        with self.assertRaisesRegex(AssertionError, 'Got 2 importance-sampling runs but 1 proposal densities'):
             combine_weights([weighted_samples_1[:,1:], weighted_samples_2[:,1:]],
                             [weighted_samples_1[:,0],  weighted_samples_2[:,0]],
                             [perfect_prop])
 
-        with self.assertRaisesRegexp(AssertionError, 'Got 2 importance-sampling runs but 1 weights'):
+        with self.assertRaisesRegex(AssertionError, 'Got 2 importance-sampling runs but 1 weights'):
             combine_weights([weighted_samples_1[:,1:], weighted_samples_2[:,1:]],
                             [weighted_samples_1[:,0]],
                             [perfect_prop, perfect_prop])
 
-        with self.assertRaisesRegexp(AssertionError, "``samples\[0\]`` is not matrix like."):
+        with self.assertRaisesRegex(AssertionError, "``samples\[0\]`` is not matrix like."):
             combine_weights([range(9), weighted_samples_2[:,1:]],
                             [weighted_samples_1[:,0],  weighted_samples_2[:,0]],
                             [perfect_prop, perfect_prop])
 
-        with self.assertRaisesRegexp(AssertionError, "Dimension of samples\[0\] \(2\) does not match the dimension of samples\[1\] \(1\)"):
+        with self.assertRaisesRegex(AssertionError, "Dimension of samples\[0\] \(2\) does not match the dimension of samples\[1\] \(1\)"):
             combine_weights([weighted_samples_1[:,1:], weighted_samples_2[:,1:2]],
                             [weighted_samples_1[:,0],  weighted_samples_2[:,0]],[perfect_prop, perfect_prop])

--- a/pypmc/sampler/markov_chain_test.py
+++ b/pypmc/sampler/markov_chain_test.py
@@ -142,7 +142,7 @@ class TestMarkovChain(unittest.TestCase):
 
         mc = MarkovChain(bad_target, prop, start)
 
-        self.assertRaisesRegexp(ValueError, 'encountered NaN', mc.run)
+        self.assertRaisesRegex(ValueError, 'encountered NaN', mc.run)
 
     def test_history(self):
         # dummy; not a real proposal
@@ -357,7 +357,7 @@ class TestAdaptiveMarkovChain(unittest.TestCase):
         self.assertEqual(mc.force_acceptance_min   , test_value)
         self.assertEqual(mc.damping                , test_value)
 
-        self.assertRaisesRegexp(TypeError, r'keyword args only; try set_adapt_parameters\(keyword = value\)',
-                                mc.set_adapt_params, test_value)
-        self.assertRaisesRegexp(TypeError, r"unexpected keyword\(s\)\: ",
-                                mc.set_adapt_params, unknown_kw = test_value)
+        self.assertRaisesRegex(TypeError, r'keyword args only; try set_adapt_parameters\(keyword = value\)',
+                               mc.set_adapt_params, test_value)
+        self.assertRaisesRegex(TypeError, r"unexpected keyword\(s\)\: ",
+                               mc.set_adapt_params, unknown_kw = test_value)

--- a/pypmc/tools/indicator/indicator_factory_test.py
+++ b/pypmc/tools/indicator/indicator_factory_test.py
@@ -48,8 +48,8 @@ class TestBall(unittest.TestCase):
 
         self.assertTrue(unit_ball_with_bdy(point3d))
         self.assertTrue(unit_ball_no_bdy(point3d))
-        self.assertRaisesRegexp(ValueError, 'input has wrong dimension', unit_ball_no_bdy  , point2d)
-        self.assertRaisesRegexp(ValueError, 'input has wrong dimension', unit_ball_with_bdy, point2d)
+        self.assertRaisesRegex(ValueError, 'input has wrong dimension', unit_ball_no_bdy  , point2d)
+        self.assertRaisesRegex(ValueError, 'input has wrong dimension', unit_ball_with_bdy, point2d)
 
     def test_input_copy(self):
         center_array = np.array([.1, 2.])
@@ -110,8 +110,8 @@ class TestHyperrectangle(unittest.TestCase):
 
         self.assertTrue(unit_hr_with_bdy(point3d))
         self.assertTrue(unit_hr_no_bdy(point3d))
-        self.assertRaisesRegexp(ValueError, 'input has wrong dimension', unit_hr_with_bdy, point2d)
-        self.assertRaisesRegexp(ValueError, 'input has wrong dimension', unit_hr_no_bdy  , point2d)
+        self.assertRaisesRegex(ValueError, 'input has wrong dimension', unit_hr_with_bdy, point2d)
+        self.assertRaisesRegex(ValueError, 'input has wrong dimension', unit_hr_no_bdy  , point2d)
 
     def test_hr_wrong_init(self):
         # hyperrectangle should raise an error if any lower > upper

--- a/pypmc/tools/linalg_test.py
+++ b/pypmc/tools/linalg_test.py
@@ -33,8 +33,8 @@ class TestLinalg(unittest.TestCase):
 
         asymmetric_sigma  = np.array([[0.01 , 0.003 ]
                              ,[0.001, 0.0025]])
-        self.assertRaisesRegexp(np.linalg.LinAlgError, 'not symmetric',
-                                chol_inv_det, asymmetric_sigma)
+        self.assertRaisesRegex(np.linalg.LinAlgError, 'not symmetric',
+                               chol_inv_det, asymmetric_sigma)
 
         singular_sigma = np.array([[0.0, 0.0   , 0.0]
                                    ,[0.0, 0.0025, 0.0]
@@ -42,5 +42,5 @@ class TestLinalg(unittest.TestCase):
         negative_sigma = -1.0 * np.eye(13)
 
         for matrix in [singular_sigma, negative_sigma]:
-            self.assertRaisesRegexp(np.linalg.LinAlgError, 'not positive definite',
-                                    chol_inv_det, matrix)
+            self.assertRaisesRegex(np.linalg.LinAlgError, 'not positive definite',
+                                   chol_inv_det, matrix)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel", 'cython>=0.21', 'numpy>=1.6, <2.0']
+requires = ["setuptools>=40.8.0", "wheel", 'cython>=0.21', 'numpy>=2.0']
 build-backend = "setuptools.build_meta:__legacy__"

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ def setup_package():
         description='A toolkit for adaptive importance sampling featuring implementations of variational Bayes, population Monte Carlo, and Markov chains.',
         long_description=long_description,
         license='GPLv2',
+        python_requires='>=3.9',
         install_requires=['numpy>=1.6, <2.0', 'scipy'],
         extras_require={'testing': ['nose'], 'plotting': ['matplotlib'], 'parallelization': ['mpi4py']},
         classifiers=['Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ def setup_package():
         long_description=long_description,
         license='GPLv2',
         python_requires='>=3.9',
-        install_requires=['numpy>=1.6, <2.0', 'scipy'],
+        install_requires=['numpy>=1.6, <2.0', 'scipy', 'setuptools>=40.8.0'],
         extras_require={'testing': ['nose'], 'plotting': ['matplotlib'], 'parallelization': ['mpi4py']},
         classifiers=['Development Status :: 5 - Production/Stable',
                      'Intended Audience :: Developers',


### PR DESCRIPTION
In PR #105, @ahnitz suggested to bump to Numpy 2.0. This PR deals with the preparation:

- [x] Drop python 3.8 support, since numpy 2.0 is not supported for python <3.9
- [x] Start building against numpy 2.0 or later, which is compatible with numpy <2.0 (but not vice versa, thanks to @ahnitz for pointing this out!)
- [x] Start building for python 3.12